### PR TITLE
Test on nodejs 12 to 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "8"
   - "10"
+  - "12"
+  - "14"
+  - "16"


### PR DESCRIPTION
Node 8 and 10 are no longer LTS and should probably be removed, but I don't know what is support policy of jsreport regarding nodejs, so I keep them